### PR TITLE
I found a typo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
         exclude module: "jme3-desktop"
     }
     
-    compile jmerepo + 'jme3-android:' + jmeversion
+    compile jmerepo + ':jme3-android:' + jmeversion
     compile jmerepo + ':jme3-android-native:' + jmeversion
 
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
I was linking this repo to someone on the jme forum, when I saw that a single colon was missing. Building it without the colon would return an error.